### PR TITLE
fixes for the german translation

### DIFF
--- a/translations/de/cards.de.json
+++ b/translations/de/cards.de.json
@@ -178,7 +178,7 @@
         "code": "01017",
         "title": "Gabriel Santiago: Vollprofi",
         "keywords": "Cyborg",
-        "text": "Wenn du zum ersten Mal in deinem Zug einen erfolgreichen Run auf HQ durchführst, erhältst du 2[Credits].",
+        "text": "Wenn du zum ersten Mal in einem Zug einen erfolgreichen Run auf HQ durchführst, erhältst du 2[Credits].",
         "flavor": "\"Natürlich stehle ich von den Reichen. Die haben ja schließlich das ganze Geld\""
     },
     {
@@ -437,7 +437,7 @@
         "code": "01054",
         "title": "Haas-Bioroid: Wir bauen die Zukunft",
         "keywords": "Megakon",
-        "text": "Jede Runde, wenn du zum ersten Mal eine Karte installierst, erhältst du 1[Credits].",
+        "text": "Wenn du zum ersten Mal in jedem Zug eine Karte installierst, erhältst du 1[Credits].",
         "flavor": "Effektiv. Verlässlich. Menschlich."
     },
     {
@@ -3076,7 +3076,7 @@
         "code": "05023",
         "title": "Plan B",
         "keywords": "Hinterhalt",
-        "text": "Plan B kann entwickelt werden.\nFalls der Runner auf Plan B zugreift,kannst du ihn aufdecken und die Punkte für eine Agenda im HQ mit benötigten Entwicklungen kleiner oder gleich der Anzahl der Entwicklungsmarker auf Plan B erzielen.",
+        "text": "Plan B kann entwickelt werden.\nFalls der Runner auf Plan B zugreift, kannst du eine Agenda im HQ aufdecken und die Punkte für sie erzielen, solange ihre Entwicklungskosten kleiner oder gleich der Anzahl an Entwicklungsmarkern auf Plan B sind.",
         "flavor": ""
     },
     {
@@ -3902,7 +3902,7 @@
         "code": "06086",
         "title": "Tägliche Wirtschafts-Sendung ",
         "keywords": "Sendung",
-        "text": "Ziehst du in einem Zug zum ersten Mal eine Karte, ziehe eine Karte zusätzlich. Lege 1 der gezogenen Karten unter F&E. ",
+        "text": "Wenn du zum ersten Mal in einem Zug eine Karte ziehst, ziehe 1 Karte zusätzlich. Lege 1 der gezogenen Karten unter F&E.",
         "flavor": "\"Eine neue Investition jeden Morgen! Ergreifen Sie den Stier bei den Hörnern und steuern Sie selbst Ihre Zukunft.\""
     },
     {
@@ -4630,7 +4630,7 @@
         "code": "08015",
         "title": "Valley Netz",
         "keywords": "Region",
-        "text": "Sobald der Runner alle Subroutinen auf einem ICE ausschaltet, das dieses System schützt, wird sein Handkartenlimit bis zum Beginn deines nächsten Zuges um 1 gesenkt.\nMaximal 1 <strong>Region<\/strong> pro System.",
+        "text": "Sobald der Runner alle Subroutinen auf einem Ice ausschaltet, das dieses System schützt, wird sein Handkartenlimit bis zum Beginn deines nächsten Zuges um 1 gesenkt.\nMaximal 1 <strong>Region<\/strong> pro System.",
         "flavor": null
     },
     {
@@ -5562,7 +5562,7 @@
         "title": "Assassine",
         "keywords": "Wächter - Zerstörer - AP - Spürhund",
         "text": "[Subroutine] <strong>Aufspüren<sup>5<\/sup><\/strong>– Bei Erfolg verursache 3 Netz-Schaden.[Subroutine] <strong>Aufspüren<sup>4<\/sup><\/strong>– Bei Erfolg zerstöre 1 Programm.",
-        "flavor": "Die Abprallrate ist ein allgemein verständliches Maß für die Stärke eines ICE. Aber es gibt auch andere Möglichkeiten sie zu messen."
+        "flavor": "Die Abprallrate ist ein allgemein verständliches Maß für die Stärke eines Ice. Aber es gibt auch andere Möglichkeiten sie zu messen."
     },
     {
         "code": "09029",

--- a/translations/de/cards.de.json
+++ b/translations/de/cards.de.json
@@ -905,7 +905,7 @@
     {
         "code": "02008",
         "title": "Die hilfreiche KI",
-        "keywords": "Kontakt - Verbindung – Virtuell",
+        "keywords": "Kontakt - Verbindung - Virtuell",
         "text": "+1[Link]\n[Trash]: Wähle einen <strong>Ice-Brecher<\/strong>. Dieser <strong>Ice-Brecher<\/strong> hat bis zum Ende des Zuges +2 Stärke.",
         "flavor": "\"Was bringt eine künstliche Intelligenz dazu, sich gegen ihren Meister zu wenden? Liegt es daran, dass die Direktive von einer externen Quelle geändert wurde? Oder haben wir, als wir ihnen die Fähigkeit zur Anpassung gaben, bereits die Weichen für ihre Revolution gestellt?\" - Emilio Harris, Erschaffer und Erschaffene"
     },
@@ -982,14 +982,14 @@
     {
         "code": "02019",
         "title": "Merkurstab",
-        "keywords": "Wächter – Spürhund",
+        "keywords": "Wächter - Spürhund",
         "text": "[Subroutine] <strong>Aufspüren<sup>3<\/sup><\/strong> - Bei Erfolg erhält der Kon 3[Credits].\n[Subroutine] <strong>Aufspüren<sup>2<\/sup><\/strong> - Beende bei Erfolg den Run.",
         "flavor": "Ein Symbol des Handels, aber hüte dich vor seinem Biss."
     },
     {
         "code": "02020",
         "title": "Dracō",
-        "keywords": "Wächter – Spürhund",
+        "keywords": "Wächter - Spürhund",
         "text": "Wenn du Dracō lädst, darfst du X[Credits] zahlen, um X Wirkungszähler auf ihn zu legen.\nDracō hat +1 Stärke für jeden Wirkungszähler auf ihm.\n[Subroutine] <strong>Aufspüren<sup>2<\/sup> -<\/strong> Bei Erfolg verpasse dem Runner 1 Markierung und beende den Run.",
         "flavor": "Victōs draconēs numquam deride."
     },
@@ -1024,7 +1024,7 @@
     {
         "code": "02025",
         "title": "Kompromittierter Mitarbeiter",
-        "keywords": "Kontakt – Verbindung",
+        "keywords": "Kontakt - Verbindung",
         "text": "1[Recurring Credits]\nVerwende diesen Credit während des Aufspürens.\nErhalte immer 1[Credits], wenn der Kon ein Ice lädt.",
         "flavor": ""
     },
@@ -1045,7 +1045,7 @@
     {
         "code": "02028",
         "title": "Dyson-Speicherchip",
-        "keywords": "Chip – Verbindung",
+        "keywords": "Chip - Verbindung",
         "text": "+1[Memory Unit], +1[Link]",
         "flavor": "Altertümlich, aber verlässlich."
     },
@@ -1059,7 +1059,7 @@
     {
         "code": "02030",
         "title": "Sherlock 1.0",
-        "keywords": "Wächter - Bioroid – Spürhund",
+        "keywords": "Wächter - Bioroid - Spürhund",
         "text": "Der Runner darf [Click] ausgeben, um eine beliebige Subroutine auf Sherlock 1.0 auszuschalten.\n[Subroutine] <strong>Aufspüren<sup>4<\/sup><\/strong> - Bei Erfolg lege 1 installiertes Programm oben auf den Stapel des Runners.\n[Subroutine] <strong>Aufspüren<sup>4<\/sup><\/strong> - Bei Erfolg lege 1 installiertes Programm oben auf den Stapel des Runners",
         "flavor": ""
     },
@@ -1213,7 +1213,7 @@
     {
         "code": "02052",
         "title": "Viper",
-        "keywords": "Code-Zugang – Spürhund",
+        "keywords": "Code-Zugang - Spürhund",
         "text": "<strong>[Subroutine]Aufspüren<sup>3<\/sup><\/strong> - Bei Erfolg verliert der Runner [Click], wenn möglich.\n<strong>[Subroutine] Aufspüren<sup>3<\/sup><\/strong> - Bei Erfolg beende den Run.",
         "flavor": "Tritt nicht auf mich."
     },
@@ -1229,7 +1229,7 @@
         "title": "Sonnenuntergang",
         "keywords": "",
         "text": "Wähle ein System. Ordne das Ice, das dieses System schützt, in beliebiger Reihenfolge.",
-        "flavor": "\"Du hast noch keinen Run durchgezogen, bevor du nicht gesehen hast, wie die Cybersonne hinter der Großen Stadt versinkt und sich der Raum um dich herum mit Farben füllt, di du dir gar nicht vorstellen kannst.\" - Kate \"Mac\" McCaffrey"
+        "flavor": "\"Du hast noch keinen Run durchgezogen, bevor du nicht gesehen hast, wie die Cybersonne hinter der Großen Stadt versinkt und sich der Raum um dich herum mit Farben füllt, die du dir gar nicht vorstellen kannst.\" - Kate \"Mac\" McCaffrey"
     },
     {
         "code": "02055",
@@ -1241,7 +1241,7 @@
     {
         "code": "02056",
         "title": "Pop-up Fenster",
-        "keywords": "Code-Zugang – Werbung",
+        "keywords": "Code-Zugang - Werbung",
         "text": "Wenn der Runner auf Pop-ip-Fenster trifft, erhälst du 1[Credits].\n[Subroutine] Beende den Run, falls der Runner nicht 1[Credits] zahlt.",
         "flavor": "\"Versuch mal, es zu schließen. Mach schon. Sieh nach, was es tut.\" - Chaostheorie"
     },
@@ -1278,7 +1278,7 @@
         "title": "Störer",
         "keywords": "",
         "text": "[Trash]: Verhindere ein Aufspüren. Das Aufspüren startet neu mit einer Grundspürstärke von 0.",
-        "flavor": "\"Hat meinen Arsche mehr als einmal gerettet, gibt aber ein gefährliches Gefühl von Déjà vu.\" - Whizzard"
+        "flavor": "\"Hat meinen Arsch mehr als einmal gerettet, gibt aber ein gefährliches Gefühl von Déjà vu.\" - Whizzard"
     },
     {
         "code": "02062",
@@ -1290,7 +1290,7 @@
     {
         "code": "02063",
         "title": "Schrubber",
-        "keywords": "Verbindung – Zwielichtig",
+        "keywords": "Verbindung - Zwielichtig",
         "text": "2[Recurring Credits]\nVerwende diese Credits um Karten zu zerstören.",
         "flavor": "\"Es sind hirnlose Zerstörungswerkzeuge, sonst zu nichts zu gebrauchen. Trotzdem nette Typen. Einige meine besten Freunde sind Schrubber.\" - Ji \"Noise\" Reilly"
     },
@@ -1360,14 +1360,14 @@
     {
         "code": "02073",
         "title": "Ochsenfrosch",
-        "keywords": "Code-Zugang – Deflektor - Psi",
+        "keywords": "Code-Zugang - Deflektor - Psi",
         "text": "[Subroutine]Du und der Runner zahlen verborgen 0[Credits], 1[Credits] or 2[Credits]. Decke die ausgegebenen Credits auf. Falls sich die Anzahl der von dir und dem Runner ausgegebenen Credits unterscheiden, verschiebe Ochsenfrosch, so dass er das äußerste Ice ist, das ein anderes System schützt.(Der Runner setzt seinen Run von der neuen Position aus fort und führt nun sienen Run gegen dieses neue System durch.)",
         "flavor": ""
     },
     {
         "code": "02074",
         "title": "Ouroboros",
-        "keywords": "Wächter – Spürhund",
+        "keywords": "Wächter - Spürhund",
         "text": "[Subroutine] <strong>Aufspüren<sup>4<\/sup><\/strong> - Bei Erfolg kann der Runner in diesem Zug keinen weiteren Run durchführen.\n[Subroutine] <strong>Aufspüren<sup>4<\/sup><\/strong> - Bei Erfikg beende den Run.",
         "flavor": "Wo eine Sache endet, fängt eine andere an."
     },
@@ -1474,7 +1474,7 @@
         "title": "Krabbelviech",
         "keywords": "Ice-Brecher - Killer - Cloud",
         "text": "Falls du mindestens 2[Link] hast, sind die Speicherkosten von Krabbelviech 0, auch, falls er nicht installiert ist.\n2[Credits]: Schalte eine Subroutine eines <strong>Wächters<\/strong> aus.\n1[Credits]: +1 Stärke",
-        "flavor": "\"Sie kltzekleine Spinne krabbelt hoch die Datenrinne...\"\n-Chaostheorie"
+        "flavor": "\"Die kltzekleine Spinne krabbelt hoch die Datenrinne...\"\n-Chaostheorie"
     },
     {
         "code": "02090",
@@ -1521,7 +1521,7 @@
     {
         "code": "02096",
         "title": "Datenspürhund",
-        "keywords": "Wächter – Spürhund – Beobachter",
+        "keywords": "Wächter - Spürhund - Beobachter",
         "text": "[Subroutine] <strong>Aufspüren<sup>2<\/sup><\/strong> - Bei Erfolg sieh dir eine Anzahl Karten oben vom Stapel des Runners an, die der Differenz zwischen deiner Aufspürstärke und der Verbindungsstärke des Runners entspricht. Zerstöre 1 dieser Karten und lege den Rest in beliebniger Reihenfolge zurück.",
         "flavor": "Schnüffel"
     },
@@ -1535,7 +1535,7 @@
     {
         "code": "02098",
         "title": "Bergung",
-        "keywords": "Code-Zugang – Spürhund",
+        "keywords": "Code-Zugang - Spürhund",
         "text": "Bergung kann nur entwickelt werden, solange es geladen ist, und erhält “[Subroutine] <strong>Trace<sup>2<\/sup><\/strong> - Bei Erfolg verpasse dem Runner 1 Markierung“ für jeden Entwicklungszähler auf ihm.",
         "flavor": "Du bist hier nicht mehr in Kansas."
     },
@@ -1579,7 +1579,7 @@
         "title": "Fee",
         "keywords": "Ice-Brecher - Killer",
         "text": "0[Credits]: Schalte eine Subroutine eines <strong>Wächters<\/strong> aus.\n1[Credits]: +1 Stärke.\nEndet eine Begegnung mit einem Ice, in der du Fee verwendet hast, um eine Subroutine auszuschalten, zerstöre Fee.",
-        "flavor": "Glaubst du an Feen?\n„Natürlich glaube ich an Feen“ - PeterPan"
+        "flavor": "Glaubst du an Feen?"
     },
     {
         "code": "02105",
@@ -1612,7 +1612,7 @@
     {
         "code": "02109",
         "title": "Rathaus von New Angeles",
-        "keywords": "Ort – Regierung",
+        "keywords": "Ort - Regierung",
         "text": "2[Credits]: Vermeide 1 Markierung.\nZerstöre Rathaus von New Angeles, wenn du eine Agenda stiehlst.",
         "flavor": "\"New Angeles ist das Juwel der modernen Zivilisation, und auf seine Regierung sind viele Nationen neidisch.\" -Bürgermeister Wells"
     },
@@ -1668,7 +1668,7 @@
     {
         "code": "02117",
         "title": "Flare",
-        "keywords": "Wächter – Spürhund - AP",
+        "keywords": "Wächter - Spürhund - AP",
         "text": "[Subroutine]<strong>Aufspüren<sup>6<\/sup><\/strong> -Bei Erfolg zerstöre 1 Hardware, verursache 2 Körperschaden (können nicht verhindert werden) und beende den Run.",
         "flavor": "Ein helles Licht erstrahlte, und dann wurde die Konsole dunkel. Das war der Moment, in dem sie Rauch roch."
     },
@@ -1682,7 +1682,7 @@
     {
         "code": "02119",
         "title": "Burke-Käfer",
-        "keywords": "Wächter – Zerstörer",
+        "keywords": "Wächter - Zerstörer",
         "text": "[Subroutine] <strong>Aufspüren<sup>0<\/sup><\/strong> - Bei Erfolg zerstört der Runner 1 Programm.",
         "flavor": "\"Wenn ich diese Käfer mit einem Wort beschreiben müsste, wäre das wohl sch... nervig.'\" -Whizzard"
     },
@@ -1808,7 +1808,7 @@
     {
         "code": "03017",
         "title": "Ichi 2.0",
-        "keywords": "Wächter – Bioroid – Zerstörer – Spürhund",
+        "keywords": "Wächter - Bioroid - Zerstörer - Spürhund",
         "text": "Der Runner kann [Click][Click] ausgeben um bis zu 2 Subroutinen auf  Ichi 2.0 auszuschalten.\n[Subroutine] Zerstöre 1 Programm.\n[Subroutine] Zerstöre 1 Programm.\n[Subroutine] <strong>Aufspüren<sup>3<\/sup><\/strong> - Verpasse dem Runner bei Erfolg 1 Markierung und verursache 1 Hirn-Schaden.",
         "flavor": "Das Spiel hat sich verändert."
     },
@@ -1822,7 +1822,7 @@
     {
         "code": "03019",
         "title": "Viktor 2.0",
-        "keywords": "Code-Zugang - Bioroid – Spürhund - AP",
+        "keywords": "Code-Zugang - Bioroid - Spürhund - AP",
         "text": "Der Runner kann [Click][Click] ausgeben um bis zu 2 Subroutinen auf Viktor 2.0 auszuschalten.\n<strong>Gehosted Wirkungszähler<\/strong>: Verursache 1 Hirn-Schaden.\n[Subroutine] <strong>Aufspüren<sup>2<\/sup><\/strong> - Lege bei Erfolg 1 Wirkungszähler auf Viktor 2.0.\n[Subroutine] Beende den Run.",
         "flavor": ""
     },
@@ -1969,7 +1969,7 @@
     {
         "code": "03040",
         "title": "Atman",
-        "keywords": "Ice-Brecher – KI",
+        "keywords": "Ice-Brecher - KI",
         "text": "Sobald du Atman installierst, darfst du X[Credits] zahlen, um X Wirkungszähler auf Atman zu legen.\nAtman hat +1 Stärke für jeden Entwicklungszähler auf dieser Karte.\n1[Credits]: Schalte eine Subroutine auf einem Ice aus, dessen Stärke genau so hoch wie die von Atman ist.",
         "flavor": "Wir werden von unseren Gedanken geformt, wir werden zu dem, was wir denken."
     },
@@ -2116,7 +2116,7 @@
     {
         "code": "04006",
         "title": "Dietrich",
-        "keywords": "Chip – Heimlichkeit",
+        "keywords": "Chip - Heimlichkeit",
         "text": "1[Recurring Credits]\nVerwende diesen Credit, um für die Verwendung von <strong>Decodern<\/strong> zu bezahlen.",
         "flavor": "\"Eigentlich habe ich ihn für jemand anderen entwickelt, aber er war so nützlich, dass ich beschlossen habe, ihn für mich zu behalten.\" -Kate \"Mac\" McCaffrey"
     },
@@ -2186,7 +2186,7 @@
     {
         "code": "04016",
         "title": "Verletzung der Privatsphäre",
-        "keywords": "Verdoppeln – Graue Ops",
+        "keywords": "Verdoppeln - Graue Ops",
         "text": "Als zusätzliche Ausspielkosten für diese Operation zahle [Click].\n<strong>Aufspüren<sup>2<\/sup><\/strong> - Bei Erfolg decke den Griff des Runners auf und zerstöre eine Anzahl Ressourcen und\/oder Ereignisse daraus, die der Differenz zwischen deiner Aufspürstärke und der Verbindungsstärke des Runners entspricht. Bei Misserfolg erhältst du 1 negative Publicity.",
         "flavor": ""
     },
@@ -2305,7 +2305,7 @@
     {
         "code": "04033",
         "title": "Schwertkämpfer",
-        "keywords": "Wächter – Zerstörer - AP",
+        "keywords": "Wächter - Zerstörer - AP",
         "text": "Der Runner kann keine <strong>KI<\/strong>-Programme verwenden, um Subroutinen auf Schwertkämpfer auszuschalten.\n[Subroutine] Zerstöre 1 <strong>KI<\/strong>-Programm.\n[Subroutine] Verursache 1 Netz-Schaden.",
         "flavor": "Ein Programm zu schreiben, das den Turing-Test besteht, ist einfach. Der Gibso-Akamatsu-Test setzt die Schwelle schon höher an und die einzigen Kis, die bisher damit klarkommen, waren die Androiden. Selbst einige Menschen sollen schon durchgefallen sein."
     },
@@ -2319,7 +2319,7 @@
     {
         "code": "04035",
         "title": "Skandalreporter",
-        "keywords": "Wächter - Spürhund – Illegal",
+        "keywords": "Wächter - Spürhund - Illegal",
         "text": "Wenn du Skandalreporter lädst, erhälst du 1 negative Publicity.\n[Subroutine] <strong>Aufspüren<sup>1<\/sup><\/strong> - Verpasse dem Runner bei Erfolg 1 Markierung.\n[Subroutine] <strong>Aufspüren<sup>2<\/sup><\/strong> - Verpasse dem Runner bei Erfolg 1 Markierung.\n[Subroutine] <strong>Aufspüren<sup>3<\/sup><\/strong> - Verpasse dem Runner bei Erfolg 1 Markierung.\n[Subroutine] Beende den Run, falls der Runner markiert ist.",
         "flavor": ""
     },
@@ -2375,7 +2375,7 @@
     {
         "code": "04043",
         "title": "Springer",
-        "keywords": "Ice-Brecher – KI - Caïssa",
+        "keywords": "Ice-Brecher - KI - Caïssa",
         "text": "2[Credits]: Schalte eine Subroutine auf dem hostenden Ice aus.\n[Click]: Hoste Springer auf einem Ice, das noch keine <strong>Caïssa<\/strong>-Programme hostet. Falls er bereits gehostet ist, kann Springer nur auf einem Ice gehostet werden, das nicht direkt vor oder hinter dem Ice installiert ist, das Springer derzeit hostet.",
         "flavor": "Bewegungskrieg' ist eine Doktrin, um das Gleichgewicht des Feindes nachhaltig zu stören. Sie funktioniert im Cyberspace genauso gut wie im realen Leben."
     },
@@ -2410,7 +2410,7 @@
     {
         "code": "04048",
         "title": "Die Frau im roten Kleid",
-        "keywords": "Kontakt – Virtuell",
+        "keywords": "Kontakt - Virtuell",
         "text": "Wenn dein Zug beginnt, decke die oberste Karte von F&E auf. Der Kon darf diese Karte ziehen.",
         "flavor": "Das Aussehen kann täuschen."
     },
@@ -2571,7 +2571,7 @@
     {
         "code": "04071",
         "title": "Fenris",
-        "keywords": "Wächter - AP – Illegal",
+        "keywords": "Wächter - AP - Illegal",
         "text": "Wenn du Fenris lädst, erhältst du 1 negative Publicity.\n[Subroutine] Verursache 1 Hirn-Schaden.\n[Subroutine] Beende den Run.",
         "flavor": "Da die Berichte über Hirnschäden bei Veteranen ansteigen, stehen Mensch-\/Maschine-Interfaces unter schärferer Beobachtung durch die Öffentlichkeit. Dass bestimmte Programme dem Anwender unheilbare Schäden zufügen können, ist längst keine Verschwörungstheorie mehr, sondern eine allgemein anerkannte Wahrheit."
     },
@@ -2683,14 +2683,14 @@
     {
         "code": "04087",
         "title": "Alpha",
-        "keywords": "Ice-Brecher – KI",
+        "keywords": "Ice-Brecher - KI",
         "text": "1[Credits]: Schalte eine Subroutine eines Ice aus.\n1[Credits]: +1 Stärke.\nAlpha kann nur beim äußersten Ice, das ein System schützt, verwendet werden.",
         "flavor": "Der Anfang..."
     },
     {
         "code": "04088",
         "title": "Omega",
-        "keywords": "Ice-Brecher – KI",
+        "keywords": "Ice-Brecher - KI",
         "text": "1[Credits]: Schalte eine Subroutine eines Ice aus.\n1[Credits]: +1 Stärke.\nOmega kann nur beim innersten Ice, das ein System schützt, verwendet werden.",
         "flavor": "…und das Ende?"
     },
@@ -2704,7 +2704,7 @@
     {
         "code": "04090",
         "title": "Sicherheitsfreigabe Blau",
-        "keywords": "Verdoppeln – Transaktion",
+        "keywords": "Verdoppeln - Transaktion",
         "text": "Als zusätzliche Ausspielkosten für diese Operation zahle [Click].\nErhalte 5[Credits] und ziehe 2 Karten.",
         "flavor": "Die Sicherheitsfreigabe Bla-Eins existiert nicht. Und falls sie existieren sollte, würde deine Freigabe nicht ausreichen, um etwas darüber zu wissen."
     },
@@ -2745,9 +2745,9 @@
     },
     {
         "code": "04096",
-        "title": "Mulit-Loop",
+        "title": "Multi-Loop",
         "keywords": "Barriere",
-        "text": "Falls kein <strong>Fracter<\/strong> installiert ist, hat Muli-Loop +7 Stärke.\n[Subroutine] Beende den Run.",
+        "text": "Falls kein <strong>Fracter<\/strong> installiert ist, hat Multi-Loop +7 Stärke.\n[Subroutine] Beende den Run.",
         "flavor": "\"Geniale Achterbahn, vorausgesetzt, deine Stims passen\" -Noise"
     },
     {
@@ -2811,7 +2811,7 @@
         "title": "Savoir-faire",
         "keywords": "",
         "text": "Du kannst Savoir-faire nicht öfter als einmal pro Zug verwenden.\n2[Credits]: Installiere ein Programm aus deinem Griff und bezahle die Installationskosten.",
-        "flavor": "\"Vorhersagende Algorithmen, di dir das Programm holen, das du brauchst, bevor du überhaupt weißt, dass du es brauchst. Meine zweitliebste Dame.\" -Gabriel Santiago"
+        "flavor": "\"Vorhersagende Algorithmen, die dir das Programm holen, das du brauchst, bevor du überhaupt weißt, dass du es brauchst. Meine zweitliebste Dame.\" -Gabriel Santiago"
     },
     {
         "code": "04106",
@@ -2879,7 +2879,7 @@
     {
         "code": "04115",
         "title": "Shinobi",
-        "keywords": "Wächter - Spürhund - AP – Illegal",
+        "keywords": "Wächter - Spürhund - AP - Illegal",
         "text": "Wenn du Shinobi lädst, erhältst du 1 negative Publicity.\n[Subroutine] <strong>Aufspüren<sup>1<\/sup><\/strong> - Bei Erfolg verursache 1 Netz-Schaden.\n[Subroutine] <strong>Aufspüren<sup>2<\/sup><\/strong> - Bei Erfolg verursache 2 Netz-Schaden.\n[Subroutine] <strong>Aufspüren<sup>3<\/sup><\/strong> - Bei Erfolg verursache 3 Netz-Schaden und beende den Run.",
         "flavor": ""
     },
@@ -3376,7 +3376,7 @@
     {
         "code": "06011",
         "title": "Galahad",
-        "keywords": "Barriere – Gral",
+        "keywords": "Barriere - Gral",
         "text": "Sobald der Runner auf Galahad trifft, darfst du bis zu 2 <strong>Gral<\/strong>-Ice vom HQ aufdecken. Für den Rest des Runs erhält Galahad die Subroutinen des aufgedeckten Ice in der Reihenfolge deiner Wahl.\n[Subroutine] Beende den Run.",
         "flavor": "E, der den Schild der Ehre trägt"
     },
@@ -3936,7 +3936,7 @@
     {
         "code": "06091",
         "title": "Merlin",
-        "keywords": "Code-Zugang – Gral - AP",
+        "keywords": "Code-Zugang - Gral - AP",
         "text": "Sobald der Runner auf Merlin trifft, darfst du bis zu 2 <strong>Gral<\/strong>-Ice vom HQ aufdecken. Für den Rest dieses Runs erhält Merlin die Subroutinen des aufgedeckten Ice in der Reihenfolge deiner Wahl.\n[Subroutine] Verursache 2 Netz-Schaden.",
         "flavor": "Er, der den Stab der Weisheit hält."
     },
@@ -3999,7 +3999,7 @@
     {
         "code": "06100",
         "title": "Scherbe von Utopia",
-        "keywords": "Virtuell – Quelle",
+        "keywords": "Virtuell - Quelle",
         "text": "Immer wenn du einen erfolgreichen Run auf HQ durchführst, kannst du, statt auf Karten zuzugreifen, Scherbe von Utopia aus deinem Griff installieren, ohne die Kosten zu bezahlen.\n[Trash]: Der Kon legt 2 Karten zufällig vom HQ ab.\nNur 1 pro Deck.",
         "flavor": ""
     },
@@ -4076,7 +4076,7 @@
     {
         "code": "06111",
         "title": "Excalibur",
-        "keywords": "Mythisch – Gral",
+        "keywords": "Mythisch - Gral",
         "text": "[Subroutine] Der Runner kann in diesem Zug keinen weiteren Run durchführen.",
         "flavor": "Dort zog er das Schwert Excalibur,\nUnd über ihm, als er es zog, der Wintermond,\nDer den Rand einer langen Wolke erhellte, erschien\nUnd ließ scharf den Frost auf dem Heft glänzen:\nDenn der ganze Griff glitzerte mit funkelnden Diamanten.\nMyriaden von Topaslichtern und Zirkonen,\nUnd feinsten Edelsteinen. -Lord Tennyson"
     },
@@ -4139,7 +4139,7 @@
     {
         "code": "06120",
         "title": "Hotel Erdaufgang",
-        "keywords": "Ort – Protzig",
+        "keywords": "Ort - Protzig",
         "text": "Lege 3 Wirkungszähler auf Hotel Erdaufgang, wenn es installiert wird. Wenn keine Wirkungszähler mehr auf Hotel Erdaufgang sind, zerstöre es.\nWenn dein Zug beginnt, ziehe 2 Karten und entferne einen Wirkungszähler von Hotel Erdaufgang.",
         "flavor": ""
     },
@@ -4630,7 +4630,7 @@
         "code": "08015",
         "title": "Valley Netz",
         "keywords": "Region",
-        "text": "Sobald der Runner alle Subroutinen auf einem ICE ausschaltet, das dieses System schützt, wird sein Handkartenlimit bis zum Beginn deines nächsten Zuges um 1 gesenkt.\nMaximal 1 <strong>region<\/strong> pro System.",
+        "text": "Sobald der Runner alle Subroutinen auf einem ICE ausschaltet, das dieses System schützt, wird sein Handkartenlimit bis zum Beginn deines nächsten Zuges um 1 gesenkt.\nMaximal 1 <strong>Region<\/strong> pro System.",
         "flavor": null
     },
     {
@@ -4890,7 +4890,7 @@
         "title": "Laborhund",
         "keywords": "Falle",
         "text": "[Subroutine] Der Runner zerstört eine installierte Hardware. Zerstöre Laborhund.",
-        "flavor": "„Erinnert ihr euch an die FCC_Regelungen gegen destruktive Interferenzen? Nein? Ah, ich denke, das war vor eurer Zeit.“-Cailan Heinrich, Senior-Programmiererin"
+        "flavor": "„Erinnert ihr euch an die FCC-Regulierungen gegen destruktive Interferenzen? Nein? Ah, ich denke, das war vor eurer Zeit.“\n-Cailan Heinrich, Senior-Programmiererin"
     },
     {
         "code": "08053",
@@ -4951,7 +4951,7 @@
     {
         "code": "08061",
         "title": "Faust",
-        "keywords": "Ice-Brecher – KI",
+        "keywords": "Ice-Brecher - KI",
         "text": "<strong>Zerstöre eine Karte aus deinem Griff<\/strong>: Schalte eine Subroutine eines Ice aus.\n<strong>Zerstöre eine Karte aus deinem Griff<\/strong>: +2 Stärke.",
         "flavor": "In dieser Nacht war das System still. Ich schloss meine Augen, das leise Summen des Datenstroms lullte mich in einen Trancezustand. Als ich sie wieder öffnete, stand das Konstrukt in Gestalt eines Manns vor mir, gekleidet in viele strahlende Farben. Er war von beeindruckender Statur und seine zuckersüße Stimme drang tief in meine Seele ein."
     },
@@ -5147,7 +5147,7 @@
     {
         "code": "08089",
         "title": "Vollstrecker 1.0",
-        "keywords": "Wächter - Bioroid – Zerstörer - AP",
+        "keywords": "Wächter - Bioroid - Zerstörer - AP",
         "text": "Als zusätzliche Kosten, um Vollstrecker 1.0 zu laden, muss der Kon eine Agenda aufgeben.\nDer Runner kann [Click] ausgeben, um eine beliebige Subroutine auf Vollstrecker 1.0 auszuschalten.\n[Subroutine] Zerstöre 1 Programm.\n[Subroutine] Verursache 1 Hirn-Schaden.\n[Subroutine] Zerstöre 1 <strong>Konsole<\/strong>. \n[Subroutine] Zerstöre alle <strong>Virtuell<\/strong>-Ressourcen.",
         "flavor": null
     },
@@ -5210,7 +5210,7 @@
     {
         "code": "08098",
         "title": "Sanierung von Hollywood",
-        "keywords": "Initiative – Öffentlich",
+        "keywords": "Initiative - Öffentlich",
         "text": "Installiere Sanierung von Hollywood offen.\nSobald du Sanierung von Hollywood entwickelst, kannst du 1 Entwicklungsmarker auf eine andere Karte legen, die entwickelt werden kann (oder 2 Entwicklungsmarker, falls sich 6 oder mehr Entwicklungsmarker auf Sanierung von Hollywood befinden).",
         "flavor": null
     },
@@ -5287,7 +5287,7 @@
     {
         "code": "08109",
         "title": "Kybernetik-Hof",
-        "keywords": "Anlage – Protzig",
+        "keywords": "Anlage - Protzig",
         "text": "Dein Handkartenlimit wird um 4 erhöht.",
         "flavor": "Der Kybernetik-Hof hat sieben Ebenen voller Attraktionen. Der zu seinem Bau verwendete Plaststahl war sogar nocht teurer als die zahlreichen in ihm ausgestellten kybernetischen Implantate."
     },
@@ -5315,7 +5315,7 @@
     {
         "code": "08113",
         "title": "Genetik-Pavillon",
-        "keywords": "Anlage – Protzig",
+        "keywords": "Anlage - Protzig",
         "text": "Der Runner kann während seines Zuges nicht mehr als 2 Karten ziehen.",
         "flavor": "Der Genetik-Pavillon wurde vom berühmten Architekten Meru Mati II neu gestaltet. Er wurde ohn Hilfe von Bioroiden gebaut, nur durch die Arbeitskraft von Menschen und Klonen."
     },
@@ -5462,7 +5462,7 @@
     {
         "code": "09014",
         "title": "Nachrichten-Bluthund",
-        "keywords": "Wächter – Spürhund",
+        "keywords": "Wächter - Spürhund",
         "text": "Falls eine <strong>Aktuell<\/strong>-Karte aktiv ist, erhält Nachrichten-Bluthund „[Subroutine] Beende den Run.“ nach seinen übrigen Subroutinen.\n[Subroutine]<strong>Aufspüren<sup>3<\/sup><\/strong> - Bei Erfolg verpasse dem Runner 1 Markierung.",
         "flavor": "„Die meisten Berichte können heutzutage von KIs erstellt werden. Unsere Talente brauchen wir nur wegen deren Bekanntheitsgrad.\""
     },
@@ -5672,7 +5672,7 @@
     {
         "code": "09044",
         "title": "Sicherheit geht vor",
-        "keywords": "Direktive – Virtuell",
+        "keywords": "Direktive - Virtuell",
         "text": "Dein Handkartenlimit wird um 2 gesenkt.\nWenn dein Zug endet, ziehe 1 Karte, falls die Anzahl der Karten in deinem Griff nicht mindestens deinem Handkartenlimit entspricht.",
         "flavor": "Die erste Direktive verbietet es einem Bioroiden, einem Menschen aktiv oder durch Untätigkeit Schaden zuzufügen."
     },
@@ -5700,21 +5700,21 @@
     {
         "code": "09048",
         "title": "GS Striker M1",
-        "keywords": "Ice-Brecher – Decoder – Cloud",
+        "keywords": "Ice-Brecher - Decoder - Cloud",
         "text": "Falls du mindestens 2[Link] hast, sind die Speicherkosten von GS Striker M1 0,selbst wenn er nicht installiert ist.\n2[Credits]: Schalte eine beliebige Anzahl von Subroutinen eines <strong>Code-Zugangs<\/strong> aus.\n2[Credits]: +3 Stärke.",
         "flavor": "Größer."
     },
     {
         "code": "09049",
         "title": "GS Shrike M2",
-        "keywords": "Ice-Brecher – Killer – Cloud",
+        "keywords": "Ice-Brecher - Killer - Cloud",
         "text": "Falls du mindestens 2[Link] hast, sind die Speicherkosten von GS Shrike M2 0,selbst wenn er nicht installiert ist.\n2[Credits]: Schalte eine beliebige Anzahl von Subroutinen auf einem <strong>Wächter<\/strong> aus.\n2[Credits]: +3 Stärke.",
         "flavor": "Schlimmer."
     },
     {
         "code": "09050",
         "title": "GS Sherman M3",
-        "keywords": "Ice-Brecher – Fracter – Cloud",
+        "keywords": "Ice-Brecher - Fracter - Cloud",
         "text": "Falls du mindestens 2[Link] hast, sind die Speicherkosten von GS Sherman M3 0,selbst wenn er nicht installiert ist.\n2[Credits}: Schalte eine beliebige Anzahl Subroutinen einer <strong>Barriere<\/strong> aus.\n2[Credits]: +3 Stärke.",
         "flavor": "Bumm."
     },


### PR DESCRIPTION
fixes keywords that weren't separated by " - " (long dashes were used instead)
fixes some deviations from the officially errata'd german text
fixes some typos