### PR TITLE
en: Add missing subtype for Witness Tampering

### DIFF
--- a/pack/dt.json
+++ b/pack/dt.json
@@ -314,7 +314,7 @@
         "faction_cost": 1,
         "flavor": "\"Now, let's talk about how little you remember of the events of June sixth through sixteenth.\"",
         "illustrator": "Lorraine Schleter",
-        "keywords": "Double",
+        "keywords": "Double - Gray Ops",
         "pack_code": "dt",
         "position": 118,
         "quantity": 3,


### PR DESCRIPTION
Witness Tampering is a Gray Ops in addition of a Double.