### PR TITLE
changed li tags to new lines

### DIFF
--- a/pack/23s.json
+++ b/pack/23s.json
@@ -76,7 +76,7 @@
         "faction_code": "shaper",
         "faction_cost": 3,
         "illustrator": "Kathryn Steele",
-	"keywords": "Console",
+        "keywords": "Console",
         "pack_code": "23s",
         "position": 4,
         "quantity": 3,
@@ -133,7 +133,7 @@
         "position": 8,
         "quantity": 3,
         "side_code": "runner",
-        "text": "Resolve two of the following in any order:<ul><li>Gain 3[credit].</li><li>Draw 2 cards.</li><li>Remove 1 tag.</li><li>Expose 1 piece of ice, then make a run.</li></ul>\n<strong>Designed by 2014 World Champion Dan D'Argenio.</strong>",
+        "text": "Resolve two of the following in any order:\nGain 3[credit].\nDraw 2 cards.\nRemove 1 tag.\nExpose 1 piece of ice, then make a run.\n<strong>Designed by 2014 World Champion Dan D'Argenio.</strong>",
         "title": "Deuces Wild",
         "type_code": "event",
         "uniqueness": false


### PR DESCRIPTION
Looks like this should of been done with /n not \<li> slack displays \<li> as raw tags.