### PR TITLE
remove trash cost from Scarcity of Resources

### DIFF
--- a/pack/es.json
+++ b/pack/es.json
@@ -155,7 +155,6 @@
         "side_code": "corp",
         "text": "This card is not trashed until another <strong>current</strong> is played or an agenda is stolen.\nThe install cost of each resource is increased by 2.",
         "title": "Scarcity of Resources",
-        "trash_cost": 4,
         "type_code": "operation",
         "uniqueness": false
     }


### PR DESCRIPTION
Sorry, missed a holdover from a copy/paste. This operation should not have a trash cost. 