### PR TITLE
fix trash symbol on Citadel Sanctuary

### DIFF
--- a/pack/in.json
+++ b/pack/in.json
@@ -69,7 +69,7 @@
         "position": 70,
         "quantity": 3,
         "side_code": "runner",
-        "text": "If you are tagged when your turn ends, force the Corp to \"<trace>Trace 1</trace> If unsuccessful, the Runner removes 1 tag.\"\n[Trash],<strong>trash all cards in your grip:</strong> Prevent all meat damage.",
+        "text": "If you are tagged when your turn ends, force the Corp to \"<trace>Trace 1</trace> If unsuccessful, the Runner removes 1 tag.\"\n[trash],<strong>trash all cards in your grip:</strong> Prevent all meat damage.",
         "title": "Citadel Sanctuary",
         "type_code": "resource",
         "uniqueness": true


### PR DESCRIPTION
I didn't put `[trash]` in all lowercase so the symbol isn't appearing. 