### PR TITLE
Update BoN with new wording from FAQ 3.1.1 Card Errata

### DIFF
--- a/pack/bm.json
+++ b/pack/bm.json
@@ -323,7 +323,7 @@
         "position": 38,
         "quantity": 3,
         "side_code": "corp",
-        "text": "The first time the Runner encounters a piece of ice with at least 1 advancement token on it each turn, do 1 meat damage.",
+        "text": "The first time an encounter with a piece of ice with at least 1 advancement token ends each turn, do 1 meat damage.\n<errata>Errata from FAQ 3.1.1</errata>",
         "title": "Weyland Consortium: Builder of Nations",
         "type_code": "identity",
         "uniqueness": false


### PR DESCRIPTION
In the new [FAQ 3.1.1](https://images-cdn.fantasyflightgames.com/filer_public/74/e6/74e67923-8d1e-45cd-a43c-314bacda2741/adn_faq_v311.pdf) Builder of Nations wording has changed.

Effective from the September 26th.