### PR TITLE
Add new Quorum card data from the FFG Worlds scoops

### DIFF
--- a/pack/qu.json
+++ b/pack/qu.json
@@ -35,6 +35,25 @@
         "uniqueness": false
     },
     {
+        "code": "11112",
+        "cost": 12,
+        "deck_limit": 3,
+        "faction_code": "jinteki",
+        "faction_cost": 2,
+        "flavor": "\"Ice is not meant to kill; just slow or cripple the Runner. Killing is my job.\" - Tori Hanzō",
+        "illustrator": "Yog Joshi",
+        "keywords": "Barrier - AP",
+        "pack_code": "qu",
+        "position": 112,
+        "quantity": 3,
+        "side_code": "corp",
+        "strength": 8,
+        "text": "Whenever the Runner breaks a subroutine on Chiyashi while there is an <strong>AI</strong> installed, trash the top 2 cards of the Runner's stack.\n[subroutine] Do 2 net damage.\n[subroutine] Do 2 net damage.\n[subroutine] End the run.",
+        "title": "Chiyashi",
+        "type_code": "ice",
+        "uniqueness": false
+    },
+    {
         "code": "11117",
         "cost": 2,
         "deck_limit": 3,


### PR DESCRIPTION
Scoops images [here](http://imgur.com/a/x1S3p).

[Veritas](http://i.imgur.com/eu1xkWJ.png) seem to be from this pack as well, but I couldn't identify exactly the card number so I decided not to add it to these changes.