### PR TITLE
Add Martial Law release date

### DIFF
--- a/packs.json
+++ b/packs.json
@@ -194,7 +194,7 @@
     {
         "code": "ml",
         "cycle_code": "flashpoint",
-        "date_release": null,
+        "date_release": "2016-12-08",
         "name": "Martial Law",
         "position": 5,
         "size": 20


### PR DESCRIPTION
Martial Law is expected to be released on December 8th, 2016. Feel free to wait until it's FFG-official before merging this, if you want.