### PR TITLE
Fix card definition for Jinteki ID AgInfusion

### DIFF
--- a/pack/eas.json
+++ b/pack/eas.json
@@ -59,7 +59,6 @@
         "code": "12052",
         "deck_limit": 1,
         "faction_code": "jinteki",
-        "flavor": "New miracles for a new world",
         "influence_limit": 17,
         "keywords": "Division",
         "minimum_deck_size": 45,
@@ -68,7 +67,7 @@
         "quantity": 3,
         "side_code": "corp",
         "text": "Once per turn, instead of rezzing an approached piece of ice, you may trash it to choose another server. The Runner is now running on that server and encountering the outermost piece of ice, if any.",
-        "title": "AgInfusion",
+        "title": "AgInfusion: New Miracles for a New World",
         "type_code": "identity",
         "uniqueness": false
     },


### PR DESCRIPTION
As pointed by Joel, the IDs don't have the flavour text and the extra text is contained in the title itself.