### PR TITLE
Fix duplicate and misspelt artist names

### DIFF
--- a/pack/dc.json
+++ b/pack/dc.json
@@ -6,7 +6,7 @@
         "faction_code": "anarch",
         "faction_cost": 4,
         "flavor": "(...) Archivist tracks all the clans and their (...)mbers, and official dealings clans have with the (...)ous corps. Half law clerk and half historian, (...)ields a tremendous amount of power doing a job no one else wants, but none can do without.",
-        "illustrator": "Matthew Zeilinger",
+        "illustrator": "Matt Zeilinger",
         "keywords": "Connection",
         "pack_code": "dc",
         "position": 3,

--- a/pack/ml.json
+++ b/pack/ml.json
@@ -44,7 +44,7 @@
         "faction_code": "shaper",
         "faction_cost": 1,
         "flavor": "Her ability to analyze and adapt mid-run bordered on the paranormal.",
-        "illustrator": "Hannah Christensen",
+        "illustrator": "Hannah Christenson",
         "keywords": "Run - Stealth",
         "pack_code": "ml",
         "position": 83,

--- a/pack/om.json
+++ b/pack/om.json
@@ -149,7 +149,7 @@
         "faction_code": "neutral-runner",
         "faction_cost": 0,
         "flavor": "\"I've been logging online with babes all day. Don't worry, the connections are clean. I guarantee it.\"",
-        "illustrator": "Zefanya Maega",
+        "illustrator": "Zefanya Langkan Maega",
         "keywords": "Connection",
         "pack_code": "om",
         "position": 9,

--- a/pack/so.json
+++ b/pack/so.json
@@ -60,7 +60,7 @@
         "deck_limit": 3,
         "faction_code": "haas-bioroid",
         "faction_cost": 1,
-        "illustrator": "Michal Milkowski",
+        "illustrator": "Michał Miłkowski",
         "keywords": "Barrier",
         "pack_code": "so",
         "position": 29,

--- a/pack/st.json
+++ b/pack/st.json
@@ -313,7 +313,7 @@
         "deck_limit": 3,
         "faction_code": "weyland-consortium",
         "faction_cost": 3,
-        "illustrator": "Zefanya Maega",
+        "illustrator": "Zefanya Langkan Maega",
         "pack_code": "st",
         "position": 38,
         "quantity": 3,

--- a/pack/tc.json
+++ b/pack/tc.json
@@ -76,7 +76,7 @@
         "faction_code": "criminal",
         "faction_cost": 3,
         "flavor": "The first credited icebreaker was nothing more than a unique script to bypass the security calls on a Gibson 3 Data Sentry. Garrote has over 20,000 times the data as that first breaker, but the idea remains the same: cut off the power source from the network, and then smash on through.",
-        "illustrator": "Zefanya Maega",
+        "illustrator": "Zefanya Langkan Maega",
         "keywords": "Icebreaker - Killer",
         "memory_cost": 2,
         "pack_code": "tc",


### PR DESCRIPTION
As well as fixing some trivial misspellings, I've taken the liberty of homogenising a couple of names. Specifically, I've renamed all instances of `Zefanya Maega` to `Zefanya Langkan Maega`, and one instance of `Matthew Zeilinger` to `Matt Zeilinger`.

While the previous state of the data does accurately reflect the cards (e.g. Zefanya's middle name is used on Fast Track, but not on John Masanori), I feel that the ability to search by a single, consistent name across all cards is more useful than strict adherence to physical card text.

I chose the long-form of Zefanya's name on the basis that it was most recently used (in Honor and Profit, as opposed to previous short-form uses in the Spin Cycle), and chose Matt as opposed to Matthew Zeilinger because come on, who calls him Matthew Zeilinger.