### PR TITLE
Update td.json

### DIFF
--- a/pack/td.json
+++ b/pack/td.json
@@ -472,4 +472,38 @@
         "type_code": "asset",
         "uniqueness": false
     }
+    {
+        "code": "13056",
+        "cost": 3,
+        "deck_limit": 3,
+        "faction_code": "neutral-corp",
+        "faction_cost": 0,
+        "illustrator": "Shawn Ye Zhongyi",
+        "keywords": "Code Gate",
+        "pack_code": "td",
+        "position": 56,
+        "quantity": 3,
+        "side_code": "corp",
+        "strength": 3,    
+        "text": "[subroutine] The Runner loses [click], if able\n[subroutine] The Runner trashes 1 card from his or her grip.",
+        "title": "Weir",
+        "type_code": "ice",
+        "uniqueness": false
+}{
+        "code": "13057",
+        "cost": 8,
+        "deck_limit": 3,
+        "faction_code": "neutral-corp",
+        "faction_cost": 0,
+        "illustrator": "n.n.",
+        "keywords": "Terminal - Transaction",
+        "pack_code": "td",
+        "position": 57,
+        "quantity": 3,
+        "side_code": "corp",
+        "text": "After you resolve this operation, end your action phase.\n\nGain 13[credit]",
+        "title": "IPO",
+        "type_code": "operation",
+        "uniqueness": false
+}
 ]


### PR DESCRIPTION
added #56 & #57 from "four is flatline" on bgg (https://boardgamegeek.com/blogpost/24049/netrunner-spoilers)
illustrator of IPO not readable
#56 is sorted in red sand cycle but is Copyright 2016 like TD not 2017 like Red Sand