### PR TITLE
Add new card spoiled for TD in Access Point FFG article

### DIFF
--- a/pack/td.json
+++ b/pack/td.json
@@ -363,6 +363,23 @@
         "uniqueness": true
     },
     {
+        "code": "13026",
+        "cost": 2,
+        "deck_limit": 3,
+        "faction_code": "neutral-runner",
+        "faction_cost": 0,
+        "flavor": "She left behind an encrypted trail leading to some random employee for a rival corp. She knew lazy sysops would work just hard enough to figure it out and wouldn't bother looking any deeper.",
+        "illustrator": "Jarreau Wimberly",
+        "pack_code": "td",
+        "position": 26,
+        "quantity": 3,
+        "side_code": "runner",
+        "text": "[trash]: Prevent 2 damage.",
+        "title": "Biometric Spoofing",
+        "type_code": "resource",
+        "uniqueness": false
+    },
+    {
         "code": "13027",
         "cost": 0,
         "deck_limit": 3,


### PR DESCRIPTION
Article:
https://www.fantasyflightgames.com/en/news/2017/4/12/access-points/

Also, the articles makes available images for some of the cards already
spoiled:
- [Process Automation](https://images-cdn.fantasyflightgames.com/filer_public/7c/b7/7cb73cd3-568b-4ee5-88ad-9f676e54e3b6/adn42-process-automation.png)
- [Adept](https://images-cdn.fantasyflightgames.com/filer_public/de/7d/de7d887e-3b14-49d4-b062-7af7ccbb664b/adn42-adept.png)
- [Mammon](https://images-cdn.fantasyflightgames.com/filer_public/af/4d/af4dd5b6-62bd-4f2f-8a27-0e6ecb3a9632/adn42-mammon.png)
- [Biometric Spoofing](https://images-cdn.fantasyflightgames.com/filer_public/f5/88/f588ab85-4605-4cbd-98fd-acbe54aff9c5/adn42-biometric-spoofing.png)