### PR TITLE
Fix Caveat emptor text formatting.

### DIFF
--- a/pack/vp.json
+++ b/pack/vp.json
@@ -636,7 +636,7 @@
     "side_code": "corp",
     "stripped_text": "Resolve 1 of the following: * Gain 6 credits. The Runner gets -1 allotted click for their next turn. * Gain 10 credits. The Runner gets +1 allotted click for their next turn.",
     "stripped_title": "Caveat Emptor",
-    "text": "Resolve 1 of the following:\n* Gain 6[credit]. The Runner gets −1 allotted [click] for their next turn.\n* Gain 10[credit]. The Runner gets +1 allotted [click] for their next turn.",
+    "text": "Resolve 1 of the following:\n<ul><li>Gain 6[credit]. The Runner gets −1 allotted [click] for their next turn.</li><li>Gain 10[credit]. The Runner gets +1 allotted [click] for their next turn.</li></ul>",
     "title": "Caveat Emptor",
     "type_code": "operation",
     "uniqueness": false

--- a/v2/cards/caveat_emptor.json
+++ b/v2/cards/caveat_emptor.json
@@ -11,6 +11,6 @@
   "stripped_text": "Resolve 1 of the following: * Gain 6 credits. The Runner gets -1 allotted click for their next turn. * Gain 10 credits. The Runner gets +1 allotted click for their next turn.",
   "stripped_title": "Caveat Emptor",
   "subtypes": ["transaction"],
-  "text": "Resolve 1 of the following:\n* Gain 6[credit]. The Runner gets −1 allotted [click] for their next turn.\n* Gain 10[credit]. The Runner gets +1 allotted [click] for their next turn.",
+  "text": "Resolve 1 of the following:\n<ul><li>Gain 6[credit]. The Runner gets −1 allotted [click] for their next turn.</li><li>Gain 10[credit]. The Runner gets +1 allotted [click] for their next turn.</li></ul>",
   "title": "Caveat Emptor"
 }


### PR DESCRIPTION
I updated the text formatting in airtable as well, which had `*` instead of `-` for the list delimiters.