### PR TITLE
Startup date active change

### DIFF
--- a/mwl.json
+++ b/mwl.json
@@ -1795,7 +1795,7 @@
     },
     "code": "startup-balance-update-25-04-for-classic-only",
     "date_start": "2025-04-23",
-    "name": "Startup Balance Update 25.04 (ignore active date)",
+    "name": "Startup Balance Update 25.04 (ignore active date)"
   },
   {
     "cards": {
@@ -1912,7 +1912,7 @@
     },
     "code": "startup-balance-update-25-11-for-classic-only",
     "date_start": "2025-11-03",
-    "name": "Startup Balance Update 25.11 (ignore active date)",
+    "name": "Startup Balance Update 25.11 (ignore active date)"
   },
   {
     "cards": {
@@ -2004,7 +2004,7 @@
     },
     "code": "startup-balance-update-26-03-for-classic-only",
     "date_start": "2026-03-02",
-    "name": "Startup Balance Update 26.03 (ignore active date)",
+    "name": "Startup Balance Update 26.03 (ignore active date)"
   },
   {
     "cards": {
@@ -2017,7 +2017,7 @@
     },
     "code": "startup-balance-update-26-05-for-classic-only",
     "date_start": "2026-04-01",
-    "name": "Startup Balance Update 26.05 (ignore active date)",
+    "name": "Startup Balance Update 26.05 (ignore active date)"
   },
   {
     "cards": {

--- a/mwl.json
+++ b/mwl.json
@@ -1796,7 +1796,6 @@
     "code": "startup-balance-update-25-04-for-classic-only",
     "date_start": "2025-04-23",
     "name": "Startup Balance Update 25.04 (ignore active date)",
-    "subtypes": { "current": { "deck_limit": 0 } }
   },
   {
     "cards": {
@@ -1914,7 +1913,6 @@
     "code": "startup-balance-update-25-11-for-classic-only",
     "date_start": "2025-11-03",
     "name": "Startup Balance Update 25.11 (ignore active date)",
-    "subtypes": { "current": { "deck_limit": 0 } }
   },
   {
     "cards": {
@@ -2007,7 +2005,19 @@
     "code": "startup-balance-update-26-03-for-classic-only",
     "date_start": "2026-03-02",
     "name": "Startup Balance Update 26.03 (ignore active date)",
-    "subtypes": { "current": { "deck_limit": 0 } }
+  },
+  {
+    "cards": {
+      "30006": { "deck_limit": 0 },
+      "30040": { "deck_limit": 0 },
+      "30051": { "deck_limit": 0 },
+      "30067": { "deck_limit": 0 },
+      "35045": { "deck_limit": 0 },
+      "36066": { "deck_limit": 0 }
+    },
+    "code": "startup-balance-update-26-05-for-classic-only",
+    "date_start": "2026-04-01",
+    "name": "Startup Balance Update 26.05 (ignore active date)",
   },
   {
     "cards": {
@@ -2050,19 +2060,5 @@
     "code": "standard-ban-list-26-05",
     "date_start": "2026-05-01",
     "name": "Standard Ban List 26.05"
-  },
-  {
-    "cards": {
-      "30006": { "deck_limit": 0 },
-      "30040": { "deck_limit": 0 },
-      "30051": { "deck_limit": 0 },
-      "30067": { "deck_limit": 0 },
-      "35045": { "deck_limit": 0 },
-      "36066": { "deck_limit": 0 }
-    },
-    "code": "startup-balance-update-26-05-for-classic-only",
-    "date_start": "2026-05-01",
-    "name": "Startup Balance Update 26.05 (ignore active date)",
-    "subtypes": { "current": { "deck_limit": 0 } }
   }
 ]

--- a/v2/restrictions/standard/startup_balance_update_26_05_for_classic_only.json
+++ b/v2/restrictions/standard/startup_balance_update_26_05_for_classic_only.json
@@ -7,7 +7,7 @@
     "offworld_office",
     "seamless_launch"
   ],
-  "date_start": "2026-05-01",
+  "date_start": "2026-04-01",
   "format_id": "standard",
   "id": "startup_balance_update_26_05_for_classic_only",
   "name": "Startup Balance Update 26.05 (ignore active date)"


### PR DESCRIPTION
2 changes: 

1. reordered MWL and updated the latest Startup Balance Update 26.05 to have a start date of april 1st, this should make Standard Ban List 25.05 be the "latest" ban list update for NRDB validation

2. Removed currents from Startup Balance Updates. There are no currents in the startup card pool. 